### PR TITLE
선착순 쿠폰 발급 순서보장, key 설정

### DIFF
--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/KafkaConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/KafkaConfig.java
@@ -78,37 +78,32 @@ public class KafkaConfig {
     @Bean
     public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, CouponIssueDto>>
     parallelKafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, CouponIssueDto> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(issueConsumerFactory());
-        factory.setBatchListener(true);
-        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-        factory.setConcurrency(5);
-
-        return factory;
+        return createKafkaListenerContainerFactory(issueConsumerFactory(), 5);
     }
 
     @Bean
     public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, EventClosedDto>>
     kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, EventClosedDto> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
-        factory.setBatchListener(true);
-        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-
-        return factory;
+        return createKafkaListenerContainerFactory(consumerFactory(), 0);
     }
 
     @Bean
     public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, CouponIssueDto>>
     priorityKafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, CouponIssueDto> factory =
+        return createKafkaListenerContainerFactory(issueConsumerFactory(), 3);
+    }
+
+    private <T> ConcurrentKafkaListenerContainerFactory<String, T>
+    createKafkaListenerContainerFactory(ConsumerFactory<String, T> consumerFactory, int concurrency) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(issueConsumerFactory());
+        factory.setConsumerFactory(consumerFactory);
         factory.setBatchListener(true);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-        factory.setConcurrency(3);
+
+        if (concurrency > 0) {
+            factory.setConcurrency(concurrency);
+        }
 
         return factory;
     }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/KafkaConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/KafkaConfig.java
@@ -108,6 +108,7 @@ public class KafkaConfig {
         factory.setConsumerFactory(issueConsumerFactory());
         factory.setBatchListener(true);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        factory.setConcurrency(3);
 
         return factory;
     }
@@ -117,6 +118,14 @@ public class KafkaConfig {
     public NewTopic unlimitedIssueCouponTopic() {
         return TopicBuilder.name("coupon-issue-unlimited")
                 .partitions(5)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic priorityIssueCouponTopic() {
+        return TopicBuilder.name("coupon-issue-priority")
+                .partitions(3)
                 .replicas(1)
                 .build();
     }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/kafka/CouponIssuedConsumer.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/kafka/CouponIssuedConsumer.java
@@ -29,7 +29,6 @@ public class CouponIssuedConsumer implements CouponIssueConsumer {
             containerFactory = "priorityKafkaListenerContainerFactory")
     public void issuePriorityCouponListener(List<CouponIssueDto> requests,
                                             Acknowledgment acknowledgment) {
-        /*TODO 여기서 List로 받으면 어떻게 해야될까..? for문 해서 여기서 DLQ, DLT 쓰기 어려울듯.. 재시도, 에러처리 안하는 거로..?*/
         batchCommit(requests, acknowledgment);
     }
 

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/kafka/CouponIssuedProducer.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/kafka/CouponIssuedProducer.java
@@ -21,6 +21,7 @@ public class CouponIssuedProducer implements CouponIssueProducer {
         kafkaTemplate.send(
                 MessageBuilder.withPayload(request)
                         .setHeader(KafkaHeaders.TOPIC, "coupon-issue-priority")
+                        .setHeader(KafkaHeaders.KEY, request.getCouponId())
                         .build())
         ;
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #5 

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 선착순 쿠폰 id key로 순서보장
- partition, consumer 3개로 증가 -> 같은 서비스기에 setConcurrency로 consumer 증가
- 쿠폰 id로 key 설정해 test
- kafka config 리팩토링, 중복 코드 분리

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
Consumer 3개 key CouponId로 설정
환경 : Docker에서 → 2개의 다른 쿠폰 발급 동시에 5000개 요청 → 순서보장 확인
- couponID 대로 다른 partition에 들어가는 것 확인
![스크린샷 2025-02-11 163326](https://github.com/user-attachments/assets/817ba363-3485-402a-9171-d55463a2bb9d)

**2개의 선착순 쿠폰발급 동시에 이루어질때**
**쓰레드 500, Ramp-up Period 1, Loop count 10**

- throughput 164 → 194/sec 으로 증가
- consumer lag 45초 → 30초 ⇒ 15초 감소

**쓰레드 300, Ramp-up Period 1, Loop count 17**

- Throughput 400.9/sec → 725.8/sec 증가
- consumer lag 30초 → X(없음) ⇒ 30초 감소

**한개의 선착순 쿠폰만 발급 할때** 

- consumer lag 30초 → X ⇒ 30초 감소
- 488.4/sec → 1217.4/sec

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- Consumer 3개 설정이 Kafka의 Fetch 최적화에 영향을 주어 Throughput이 증가한 것으로 보임
- 이유는 조금 더 찾아봐야 될듯!
